### PR TITLE
Fix cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 ansible-role-rabbitmq
 =========
 
-Ansible role to install RabbitMQ.
+Ansible role to install RabbitMQ from RabbitMQ repository.  
+Available on [Ansible Galaxy](https://galaxy.ansible.com/rockandska/rabbitmq)
+
+**Ansible Galaxy :**    
+![Galaxy Score](https://img.shields.io/ansible/quality/38029.svg)  
+
+**Travis Build :**  
+[![Build Status](https://travis-ci.com/rockandska/ansible-role-rabbitmq.png?branch=master)](https://travis-ci.com/rockandska/ansible-role-rabbitmq) 
 
 Requirements on remote hosts
 ------------
@@ -12,6 +19,7 @@ Requirements on remote hosts
 - socat
 - logrotate
 - python requests >= 1.0.0 ( if using bindings , exchanges, queues management provide by this role )
+- For a cluster, hosts part of the cluster should be resolvable by their hostnames
 
 #### Debian / Ubuntu
 
@@ -239,7 +247,7 @@ rabbitmq_hide_log: true
   - a multiline string with the rabbitmq config in erlang format to apply
   - will be used as rabbitmq.config for version <=3.6
   - will be used as advanced.conf for version >=3.7
-  - **don't enclose the configuration with *[* and *].* , it is done inside the template **
+  - **don't enclose the configuration with `[` and `].` , it is done inside the template**
   - example:
   ```yaml
   rabbitmq_erlang_config: |
@@ -324,7 +332,7 @@ rabbitmq_hide_log: true
 
   - not mandatory in standalone install
 
-  - **need to be a hostname/IP who exist in the inventory and should be the hostname resolvable by the hosts themselves**
+  - **need to be a hostname/IP who exist in the inventory**
 
   - Example:
 
@@ -381,7 +389,7 @@ rabbitmq_hide_log: true
     - `rabbitmq_exchanges_to_delete`
     - `rabbitmq_bindings_to_create`
     - `rabbitmq_bindings_to_delete`
-  - **Don't forget to configure rabbitmq_management to only allow connection from localhost**
+  - **Don't forget to configure rabbitmq_management to only allow connection from localhost if needed**
 
 - `rabbitmq_management_password`
 
@@ -392,7 +400,7 @@ rabbitmq_hide_log: true
     - `rabbitmq_exchanges_to_delete`
     - `rabbitmq_bindings_to_create`
     - `rabbitmq_bindings_to_delete`
-  - **Don't forget to configure rabbitmq_management to only allow connection from localhost**
+  - **Don't forget to configure rabbitmq_management to only allow connection from localhost if needed**
 
 - `rabbitmq_management_host`
 
@@ -402,7 +410,7 @@ rabbitmq_hide_log: true
     - `rabbitmq_exchanges_to_delete`
     - `rabbitmq_bindings_to_create`
     - `rabbitmq_bindings_to_delete`
-  - **Don't forget to configure rabbitmq_management to only allow connection from localhost**
+  - **Don't forget to configure rabbitmq_management to only allow connection from localhost if needed**
 
 - `rabbitmq_management_port`
 
@@ -412,7 +420,7 @@ rabbitmq_hide_log: true
     - `rabbitmq_exchanges_to_delete`
     - `rabbitmq_bindings_to_create`
     - `rabbitmq_bindings_to_delete`
-  - **Don't forget to configure rabbitmq_management to only allow connection from localhost**
+  - **Don't forget to configure rabbitmq_management to only allow connection from localhost if needed**
 
 - `rabbitmq_plugins_to_enable`
 
@@ -587,7 +595,7 @@ Example Playbook
 ```yaml
 - hosts: rabbitmq
   roles:
-  	- rockandska.erlang
+    - rockandska.erlang
     - rockandska.rabbitmq
 ```
 

--- a/tasks/config_server.yml
+++ b/tasks/config_server.yml
@@ -2,11 +2,11 @@
 - name: "[RabbitMQ] Set cluster config"
   set_fact:
     __rabbitmq_cluster_nodes: >-
-      'rabbit@{{ inventory_hostname }}',
+      'rabbit@{{ ansible_hostname }}',
       'rabbit@{{ play_hosts | map('extract',hostvars)
                             | selectattr('rabbitmq_slave_of','defined')
                             | selectattr('rabbitmq_slave_of', 'equalto', inventory_hostname)
-                            | map(attribute='inventory_hostname') | join("','rabbit@") }}'
+                            | map(attribute='ansible_hostname') | join("','rabbit@") }}'
   delegate_facts: true
   delegate_to: "{{ item }}"
   with_items:
@@ -40,19 +40,19 @@
 - name: "[RabbitMQ] Copy custom server config (erlang format)"
   template:
     src: "{{ rabbitmq_erlang_tpl }}"
-    dest: "/etc/rabbitmq/{{ ( rabbitmq_series is version('3.7', '>=') ) | ternary('advanced.config','rabbitmq.config') }}"
+    dest: "/etc/rabbitmq/{{ rabbitmq_series is version('3.7', '>=') | ternary('advanced.config','rabbitmq.config') }}"
     force: true
     mode: 0644
     owner: root
   notify:
     - restart rabbitmq
   when:
-    - rabbitmq_erlang_config | d("") | trim | length > 0
-    - rabbitmq_erlang_config != None
+    - (rabbitmq_erlang_config | d("") | trim | length > 0 and rabbitmq_erlang_config != None)
+      or __rabbitmq_cluster_nodes | d("") | trim | length != 0
 
 - name: "[RabbitMQ] Remove custom erlang config file if rabbitmq_erlang_config is empty"
   file:
-    path: "/etc/rabbitmq/{{ ( rabbitmq_series is version('3.7', '>=') ) | ternary('advanced.config','rabbitmq.config') }}"
+    path: "/etc/rabbitmq/{{ rabbitmq_series is version('3.7', '>=') | ternary('advanced.config','rabbitmq.config') }}"
     state: absent
   notify:
     - restart rabbitmq

--- a/tasks/pre_checks.yml
+++ b/tasks/pre_checks.yml
@@ -101,7 +101,8 @@
 - name: "[RabbitMQ] Test that the users to delete are not part of those to create"
   assert:
     that:
-      - (rabbitmq_users_to_create | map(attribute='user') | list) | intersect(rabbitmq_users_to_delete) | list | length == 0
+      - (rabbitmq_users_to_create | map(attribute='user') | list)
+        | intersect(rabbitmq_users_to_delete) | list | length == 0
   when:
     - rabbitmq_users_to_delete | length > 0
 

--- a/templates/etc/rabbitmq/erlang.config.j2
+++ b/templates/etc/rabbitmq/erlang.config.j2
@@ -1,10 +1,12 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "false"
 [
+{% if rabbitmq_erlang_config != None and rabbitmq_erlang_config | d("") | length > 0 %}
 {% for line in rabbitmq_erlang_config.split('\n') %}
   {{ line }}
 {% endfor %}
+{% endif %}
 {% if __rabbitmq_cluster_nodes | d("") | length > 0 and rabbitmq_peer_discovery_classic %}
-  {% if rabbitmq_erlang_config | length > 0 %}
+  {% if rabbitmq_erlang_config != None and rabbitmq_erlang_config | d("") | length > 0 %}
   ,
   {% endif %}
   {rabbit, [


### PR DESCRIPTION
- Fix cluster config
  - cluster config not created if erlang config is empty
  - need to use the hostname of the hosts instead of inventory hostname in config to avoid erlang error `Hostname mismatch`
- Update README
  - add badges
  - fix informations regarding hostname for slaves 
- Fix yamllint warning for long lines > 120