### PR TITLE
Prevent service to start at install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,21 @@
 
 - import_tasks: pre_checks.yml
 
+- name: "[RabbitMQ] Mask rabbitmq service to prevent it to start at the install"
+  systemd:
+    name: "rabbitmq-server"
+    masked: true
+  changed_when: false
+
 - include_tasks: "{{ item }}"
   with_first_found:
     - "config_{{ ansible_os_family }}.yml"
+
+- name: "[RabbitMQ] Unmask rabbitmq service"
+  systemd:
+    name: "rabbitmq-server"
+    masked: false
+  changed_when: false
 
 - import_tasks: config_logrotate.yml
 


### PR DESCRIPTION
Debian start the service directly after the install when the configuration is not done yet and prevent the cluster config to be take into account.

Didn't catch this behaviour earlier since the service was not started after the install with the docker debian systemd image.