### PR TITLE
Fix enable systemd service with ansible 2.5

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,8 +39,8 @@
 - meta: flush_handlers
 
 - name: "[RabbitMQ] Ensure rabbitmq is started and enabled"
-  service:
-    name: "rabbitmq-server"
+  systemd:
+    name: "rabbitmq-server.service"
     state: "started"
     enabled: "true"
 


### PR DESCRIPTION
Under ansible 2.5.x, the service is not enabled despite the task dedicated for this due to a problem on ansible 2.5.x if the service is not fully describe with `.service`