### PR TITLE
Added in parameter support, re-enabled policies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,12 @@ jobs:
     - <<: *test-tox
       env:
         - ANSIBLE=2.7
+    - <<: *test-tox
+        env:
+        - ANSIBLE=2.8
+    - <<: *test-tox
+        env:
+        - ANSIBLE=2.9
     - stage: mkrelease
       install:
         - pip install git-semver ansible

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ rabbitmq_bindings_to_delete: []
 rabbitmq_policies_to_create: []
 rabbitmq_policies_to_delete: []
 
+##############
+# Parameters #
+##############
+rabbitmq_parameters_to_create: []
+rabbitmq_parameters_to_delete: []
+
 #########
 # Debug #
 #########
@@ -280,7 +286,11 @@ rabbitmq_hide_log: true
     {rabbit, [
         {tcp_listeners, [{"127.0.0.1", 5672}]}
       ]
-    }
+    }##############
+     # Parameters #
+     ##############
+     rabbitmq_parameters_to_create: []
+     rabbitmq_parameters_to_delete: []
   ```
 
 - `rabbitmq_systemd_override_tpl`
@@ -609,10 +619,42 @@ rabbitmq_hide_log: true
         vhost: vhost_test
     ```
 
+- `rabbitmq_parameters_to_create`
+
+  - list of parameters to create
+
+  - refer to [ansible doc](https://docs.ansible.com/ansible/latest/modules/rabbitmq_parameter_module.html) for mandatory options and version compatibility
+  
+  - refer to [this ansible bug report](https://github.com/ansible/ansible/issues/43027) for possible json formatting issues that may occur
+  
+  - example:
+
+    ```yaml
+     rabbitmq_parameters_to_create:
+       - component: federation
+         name: local-username
+         value: '"guest"'
+         vhost: vhost_test
+    ```
+
+- `rabbitmq_parameters_to_delete`
+
+  - list of parameters to delete
+
+  - refer to [ansible doc](https://docs.ansible.com/ansible/latest/modules/rabbitmq_parameter_module.html) for mandatory options and version compatibility
+
+  - example:
+
+    ```yaml
+    rabbitmq_parameters_to_delete:
+      - component: federation
+        name: local-username
+    ```
+
 - `rabbitmq_hide_log`
 
   - default: true
-  - don't show the log for api calls to avoid leak of sensible informations
+  - don't show the log for api calls to avoid leaking of sensitive information
   - set to false for debug
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -286,11 +286,7 @@ rabbitmq_hide_log: true
     {rabbit, [
         {tcp_listeners, [{"127.0.0.1", 5672}]}
       ]
-    }##############
-     # Parameters #
-     ##############
-     rabbitmq_parameters_to_create: []
-     rabbitmq_parameters_to_delete: []
+    }
   ```
 
 - `rabbitmq_systemd_override_tpl`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,6 +92,13 @@ rabbitmq_bindings_to_delete: []
 rabbitmq_policies_to_create: []
 rabbitmq_policies_to_delete: []
 
+
+##############
+# Parameters #
+##############
+rabbitmq_parameters_to_create: []
+rabbitmq_parameters_to_delete: []
+
 #########
 # Debug #
 #########

--- a/tasks/config_parameters.yml
+++ b/tasks/config_parameters.yml
@@ -1,0 +1,25 @@
+---
+
+- name: "[RabbitMQ] Create parameters"
+  rabbitmq_parameter:
+    component: "{{ item.component }}"
+    name: "{{ item.name }}"
+    vhost: "{{ item.vhost | default(omit)  }}"
+    value: "{{ item.value | default(omit)  }}"
+    node: "{{ item.node | default(omit) }}"
+  with_items:
+    - "{{ rabbitmq_parameters_to_create }}"
+  when:
+    - rabbitmq_is_master
+      or rabbitmq_slave_of is none
+
+- name: "[RabbitMQ] Delete unwanted parameters"
+  rabbitmq_parameter:
+    component: "{{ item.name | default(omit) }}"
+    name: "{{ item.vhost | default(omit) }}"
+    state: absent
+  with_items:
+    - "{{ rabbitmq_parameters_to_delete }}"
+  when:
+    - rabbitmq_is_master
+      or rabbitmq_slave_of is none

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,3 +53,7 @@
 - import_tasks: config_exchanges.yml
 
 - import_tasks: config_bindings.yml
+
+- import_tasks: config_parameters.yml
+
+- import_tasks: config_policies.yml


### PR DESCRIPTION
For rabbit 3.8.x policies require the latest version of ansible 2.9