### PR TITLE
Fix test conditions for setting standalone nodes and gathering facts from cluster nodes

### DIFF
--- a/tasks/config_server.yml
+++ b/tasks/config_server.yml
@@ -20,12 +20,27 @@
                     | list
                 )
               }}"
-  run_once: true
   when:
     - hostvars[item]['ansible_hostname'] is not defined
-    - rabbitmq_is_master
-      or (rabbitmq_slave_of != none
-          and rabbitmq_slave_of | d("") | length > 0)
+    - (
+        hostvars[item]['rabbitmq_is_master'] | d(False)
+          and (
+                 hostvars[item]['inventory_hostname'] == inventory_hostname
+                   or (
+                        rabbitmq_slave_of != none
+                        and hostvars[item]['inventory_hostname'] == rabbitmq_slave_of
+                      )
+               )
+      )
+      or
+      (
+        'rabbitmq_slave_of' in hostvars[item]
+          and hostvars[item]['rabbitmq_slave_of'] != none
+          and (
+                hostvars[item]['rabbitmq_slave_of'] == inventory_hostname
+                  or hostvars[item]['inventory_hostname'] == inventory_hostname
+              )
+      )
 
 - name: "[RabbitMQ] Define cluster config for master"
   set_fact:

--- a/tasks/config_server.yml
+++ b/tasks/config_server.yml
@@ -24,8 +24,8 @@
   when:
     - hostvars[item]['ansible_hostname'] is not defined
     - rabbitmq_is_master
-      or rabbitmq_slave_of != none
-      or rabbitmq_slave_of | d("") | length > 0
+      or (rabbitmq_slave_of != none
+          and rabbitmq_slave_of | d("") | length > 0)
 
 - name: "[RabbitMQ] Define cluster config for master"
   set_fact:


### PR DESCRIPTION
I've encountered two issues when trying to use the role and I'm submitting two patches to address them.

The first commit fixes the check for slave nodes. A different grouping of test conditions is necessary.
The second commit makes the role gather the hostname from the necessary nodes and not from all the master/slave nodes existing in the inventory.

The molecule tests pass for me after updating them to use Ansible 2.9 and the compatible Erlang/RabbitMQ versions. Would you like a molecule scenario for testing the fixes from this pull request?