### PR TITLE
Fix: the management plugin is not necessary to manage the policies

### DIFF
--- a/tasks/config_plugins.yml
+++ b/tasks/config_plugins.yml
@@ -7,8 +7,6 @@
       or (rabbitmq_bindings_to_create | length > 0)
       or (rabbitmq_exchanges_to_delete | length > 0)
       or (rabbitmq_exchanges_to_create | length > 0)
-      or (rabbitmq_policies_to_delete | length > 0)
-      or (rabbitmq_policies_to_create | length > 0)
       or (rabbitmq_queues_to_delete | length > 0)
       or (rabbitmq_queues_to_create | length > 0)
 

--- a/tasks/pre_checks.yml
+++ b/tasks/pre_checks.yml
@@ -111,8 +111,6 @@
       or (rabbitmq_bindings_to_create | length > 0)
       or (rabbitmq_exchanges_to_delete | length > 0)
       or (rabbitmq_exchanges_to_create | length > 0)
-      or (rabbitmq_policies_to_delete | length > 0)
-      or (rabbitmq_policies_to_create | length > 0)
       or (rabbitmq_queues_to_delete | length > 0)
       or (rabbitmq_queues_to_create | length > 0)
     - rabbitmq_users_to_delete | select('match', '^guest$') | list | length > 0


### PR DESCRIPTION
A small fix to not require the management plugin for the purpose of managing the policies.