### PR TITLE
Feat: add support for setting/deleting global parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ rabbitmq_plugins_to_disable: []
 rabbitmq_users_to_create: []
 rabbitmq_users_to_delete: []
 
+#####################
+# Global Parameters #
+#####################
+rabbitmq_global_parameters_to_create: []
+rabbitmq_global_parameters_to_delete: []
+
 ############
 # Api user #
 ############
@@ -405,6 +411,35 @@ rabbitmq_hide_log: true
     ```yaml
     rabbitmq_users_to_delete:
       - guest
+    ```
+
+- `rabbitmq_global_parameters_to_create`
+
+  - list of global parameters to create
+
+  - refer to [ansible doc](https://docs.ansible.com/ansible/latest/modules/rabbitmq_global_parameter_module.html) for
+
+  - refer to [this ansible bug report](https://github.com/ansible/ansible/issues/43027) for possible json formatting i
+
+  - example:
+
+    ```yaml
+     rabbitmq_global_parameters_to_create:
+       - name: cluster_name
+         value: "{{ 'mq-cluster' | to_json }}"
+    ```
+
+- `rabbitmq_global_parameters_to_delete`
+
+  - list of global parameters to delete
+
+  - refer to [ansible doc](https://docs.ansible.com/ansible/latest/modules/rabbitmq_global_parameter_module.html) for
+
+  - example:
+
+    ```yaml
+    rabbitmq_global_parameters_to_delete:
+      - name: cluster_name
     ```
 
 - `rabbitmq_management_user`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,12 @@ rabbitmq_plugins_to_disable: []
 rabbitmq_users_to_create: []
 rabbitmq_users_to_delete: []
 
+#####################
+# Global Parameters #
+#####################
+rabbitmq_global_parameters_to_create: []
+rabbitmq_global_parameters_to_delete: []
+
 ############
 # Api user #
 ############

--- a/molecule/alternate-3.6/playbook.yml
+++ b/molecule/alternate-3.6/playbook.yml
@@ -73,6 +73,11 @@
         destination: queue_test
         destination_type: queue
         vhost: vhost_test
+    rabbitmq_global_parameters_to_create:
+      - name: cluster_name
+        value: "{{ 'mq-cluster' | to_json }}"
+    rabbitmq_global_parameters_to_delete:
+      - name: cluster_name_not_exist
     rabbitmq_policies_to_create:
       - name: HA
         vhost: vhost_test

--- a/tasks/config_global_parameters.yml
+++ b/tasks/config_global_parameters.yml
@@ -1,0 +1,22 @@
+---
+- name: "[RabbitMQ] Create global parameters"
+  rabbitmq_global_parameter:
+    name: "{{ item.name }}"
+    value: "{{ item.value | default(omit) }}"
+    node: "{{ item.node | default(omit) }}"
+  with_items:
+    - "{{ rabbitmq_global_parameters_to_create }}"
+  when:
+    - rabbitmq_is_master
+      or rabbitmq_slave_of is none
+
+- name: "[RabbitMQ] Delete unwanted global parameters"
+  rabbitmq_global_parameter:
+    name: "{{ item.name }}"
+    node: "{{ item.node | default(omit) }}"
+    state: absent
+  with_items:
+    - "{{ rabbitmq_global_parameters_to_delete }}"
+  when:
+    - rabbitmq_is_master
+      or rabbitmq_slave_of is none

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,8 @@
 
 - import_tasks: config_users.yml
 
+- import_tasks: config_global_parameters.yml
+
 - import_tasks: config_queues.yml
 
 - import_tasks: config_exchanges.yml

--- a/tasks/pre_checks.yml
+++ b/tasks/pre_checks.yml
@@ -32,6 +32,8 @@
     - rabbitmq_plugins_to_disable
     - rabbitmq_users_to_create
     - rabbitmq_users_to_delete
+    - rabbitmq_global_parameters_to_create
+    - rabbitmq_global_parameters_to_delete
     - rabbitmq_management_user
     - rabbitmq_management_password
     - rabbitmq_management_host


### PR DESCRIPTION
Add support for global parameters.

I think that this would require Ansible 2.8 or newer because the rabbitmq_global_parameter module has been introduced in version 2.8.

I've added the test only to the alternate-3.6 scenario because with RabbitMQ 3.7 or newer there are two small issues, see ansible-collections/community.rabbitmq/pull/55.

The molecule tests pass for me after updating them to use Ansible 2.9 and the compatible Erlang/RabbitMQ versions. 