### PR TITLE
Use cloudsmith repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,10 @@ Compatibility
 
 | **RabbitMQ**     |            |
 | ---------------- | ---------- |
-| 3.6.x            | OK         |
-| 3.7.x            | OK         |
-| > 3.7            | Not tested |
-| **Erlang**       |            |
-| 20.x             | OK         |
-| 21.X             | OK         |
-| 22.X             | KO[1]      |
+| 3.6.x            | Deprecated |
+| 3.7.x            | Deprecated |
+| 3.8              |     OK[1]     |
+| > 3.8            | Not tested |
 | **Distribution** |            |
 | CentOS 7         | OK         |
 | CentOS > 7       | Not tested |
@@ -61,18 +58,18 @@ Defaults variables are inside `defaults/main.yml`
 ###########
 # Install #
 ###########
-rabbitmq_series: 3.7
+rabbitmq_series: 3.8
 rabbitmq_series_rpm_version:
 rabbitmq_series_deb_version:
 
-rabbitmq_rpm_repo_url: https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server
-rabbitmq_rpm_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+rabbitmq_rpm_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/rpm/el
+rabbitmq_rpm_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key
 rabbitmq_rpm_repo_tpl: etc/yum.repos.d/rabbitmq.repo.j2
 rabbitmq_rpm_disable_repo:
 rabbitmq_rpm_enable_repo:
 
-rabbitmq_deb_repo_url: https://dl.bintray.com/rabbitmq/debian
-rabbitmq_deb_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+rabbitmq_deb_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb
+rabbitmq_deb_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key
 rabbitmq_deb_repo_tpl: etc/apt/sources.list.d/rabbitmq.list.j2
 rabbitmq_deb_pinning_tpl: etc/apt/preferences.d/rabbitmq.j2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,18 +2,18 @@
 ###########
 # Install #
 ###########
-rabbitmq_series: 3.7
+rabbitmq_series: 3.8
 rabbitmq_series_rpm_version:
 rabbitmq_series_deb_version:
 
-rabbitmq_rpm_repo_url: https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server
-rabbitmq_rpm_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+rabbitmq_rpm_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/rpm/el
+rabbitmq_rpm_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key
 rabbitmq_rpm_repo_tpl: etc/yum.repos.d/rabbitmq.repo.j2
 rabbitmq_rpm_disable_repo:
 rabbitmq_rpm_enable_repo:
 
-rabbitmq_deb_repo_url: https://dl.bintray.com/rabbitmq/debian
-rabbitmq_deb_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+rabbitmq_deb_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb
+rabbitmq_deb_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key
 rabbitmq_deb_repo_tpl: etc/apt/sources.list.d/rabbitmq.list.j2
 rabbitmq_deb_pinning_tpl: etc/apt/preferences.d/rabbitmq.j2
 

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: rockandska.erlang
   name: ansible-role-erlang
-  version: 0.1.0
+  version: 0.1.1

--- a/molecule/resources/yaml-lint.yml
+++ b/molecule/resources/yaml-lint.yml
@@ -4,6 +4,7 @@ ignore: |
   .travis/
   .travis.yml
   meta/
+  tmp/
 
 rules:
   braces:

--- a/tasks/config_Debian.yml
+++ b/tasks/config_Debian.yml
@@ -33,5 +33,5 @@
 - name: "[RabbitMQ] Install RabbitMQ [Debian/Ubuntu]"
   apt:
     package:
-      - "rabbitmq-server{{ rabbitmq_series_deb_version | ternary ('=' + (rabbitmq_series_deb_version | string),'') }}"
+      - rabbitmq-server
     state: present

--- a/tasks/config_RedHat.yml
+++ b/tasks/config_RedHat.yml
@@ -9,7 +9,7 @@
 
 - name: "[RabbitMQ] Install RabbitMQ [RHEL/CentOS]"
   yum:
-    name: "rabbitmq-server{{ rabbitmq_series_rpm_version | ternary ('-' + (rabbitmq_series_rpm_version | string),'') }}"
+    name: "rabbitmq-server{{ rabbitmq_series_rpm_version | ternary ('-' + (rabbitmq_series_rpm_version | string),'-' + (rabbitmq_series | string) + '*') }}"
     state: present
     disablerepo: "{{ rabbitmq_rpm_disable_repo | d(omit, true) }}"
     enablerepo: "{{ rabbitmq_rpm_enable_repo | d(omit, true) }}"

--- a/templates/etc/apt/preferences.d/rabbitmq.j2
+++ b/templates/etc/apt/preferences.d/rabbitmq.j2
@@ -1,3 +1,3 @@
 Package: rabbitmq*
-Pin: {{ rabbitmq_series_deb_version | ternary('version ' + (rabbitmq_series_deb_version | string),'release o=Bintray') }}
+Pin: version {{ rabbitmq_series_deb_version | ternary( (rabbitmq_series_deb_version| string), '1:' + (rabbitmq_series | string) + '*') }}
 Pin-Priority: 1000

--- a/templates/etc/apt/sources.list.d/rabbitmq.list.j2
+++ b/templates/etc/apt/sources.list.d/rabbitmq.list.j2
@@ -1,1 +1,1 @@
-deb {{ rabbitmq_deb_repo_url }} {{ ansible_distribution_release | lower }} rabbitmq-server-v{{ rabbitmq_series }}.x
+deb {{ rabbitmq_deb_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} main

--- a/templates/etc/yum.repos.d/rabbitmq.repo.j2
+++ b/templates/etc/yum.repos.d/rabbitmq.repo.j2
@@ -1,7 +1,13 @@
 [rabbitmq]
 name=rabbitmq
-baseurl={{ rabbitmq_rpm_repo_url }}/v{{ rabbitmq_series }}.x/el/{{ ansible_distribution_major_version }}
-repo_gpgcheck=0
-gpgcheck=1
+baseurl={{ rabbitmq_rpm_repo_url }}/{{ ansible_distribution_major_version }}/noarch
+repo_gpgcheck=1
 enabled=1
 gpgkey={{ rabbitmq_rpm_gpg_url }}
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,8 @@ skipsdist = true
 [testenv]
 passenv = *
 setenv =
-  rabbitmq36: RABBITMQ_SERIES = 3.6
-  rabbitmq36: ERLANG_SERIES = 20
-  rabbitmq37: RABBITMQ_SERIES = 3.7
-  rabbitmq37: ERLANG_SERIES = 21
+  rabbitmq37: RABBITMQ_SERIES = 3.8
+  rabbitmq37: ERLANG_SERIES = 23
 deps =
     docker
     jmespath


### PR DESCRIPTION
With the end of Bintray, switch to cloudsmith

Old release < 3.8 are not available anymore so they could not be tested anymore (deprecated versions)